### PR TITLE
fix report internet

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -298,7 +298,18 @@ defmodule VintageNetQMI.Connectivity do
           # If the connection might be going down, start the timer
           # unless it's already going. If it's already going, we
           # count from that point.
-          state.grace_timer || schedule_grace_timer()
+          #
+          # However, if we have a confirmed Internet connection, trust
+          # that over the modem status.
+          if state.reported_status == :internet do
+            if state.grace_timer do
+              _ = :timer.cancel(state.grace_timer)
+            end
+
+            nil
+          else
+            state.grace_timer || schedule_grace_timer()
+          end
 
         _ ->
           # If the connection is definitely up or down, make sure


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Skips and cancels the grace timer when derived status is `:going_down` but `reported_status` is `:internet`.
> 
> - **Connectivity (`lib/vintage_net_qmi/connectivity.ex`)**:
>   - In `update_derived_status/1`, when derived status is `:going_down`, if `reported_status == :internet`:
>     - Cancel any existing `grace_timer` and do not start a new one.
>     - Otherwise, keep previous behavior (`state.grace_timer || schedule_grace_timer()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82552b0abf05afdb0ce8f6a6cb6271246a4d5e48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->