### PR TITLE
fixes to reconnect

### DIFF
--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -398,13 +398,20 @@ defmodule VintageNetQMI.Connectivity do
   defp update_connection_status(
          %{reported_status: :disconnected, derived_status: :lan} = state
        ) do
-    RouteManager.set_connection_status(
-      state.ifname,
-      :lan,
-      "QMI reports LAN connectivity"
-    )
+    # Don't reset to :lan if we've exceeded recovery attempts - stay disconnected
+    # so the watchdog can act
+    if state.soft_recovery_attempts >= 3 do
+      Logger.debug("[Connectivity] #{state.ifname}: blocking :lan transition, soft_recovery_attempts=#{state.soft_recovery_attempts}")
+      state
+    else
+      RouteManager.set_connection_status(
+        state.ifname,
+        :lan,
+        "QMI reports LAN connectivity"
+      )
 
-    %{state | reported_status: :lan}
+      %{state | reported_status: :lan}
+    end
   end
 
   defp update_connection_status(

--- a/lib/vintage_net_qmi/connectivity.ex
+++ b/lib/vintage_net_qmi/connectivity.ex
@@ -199,13 +199,21 @@ defmodule VintageNetQMI.Connectivity do
         {VintageNet, ["interface", ifname, "connection"], _, :lan, _meta},
         %{ifname: ifname} = state
       ) do
-    new_state =
-      %{state | lan?: true, reported_status: :lan}
-      |> update_derived_status()
-      |> update_connection_status()
-      |> maybe_start_soft_recovery_timer()
+    # After 3 failed recovery attempts, ignore :lan reports and stay :disconnected
+    # This allows the watchdog to act instead of oscillating forever
+    if state.soft_recovery_attempts >= 3 do
+      Logger.warning("[Connectivity] #{ifname}: ignoring :lan report after #{state.soft_recovery_attempts} failed attempts, staying :disconnected")
+      RouteManager.set_connection_status(ifname, :disconnected, "max_recovery_attempts_exceeded")
+      {:noreply, %{state | lan?: true, reported_status: :disconnected}}
+    else
+      new_state =
+        %{state | lan?: true, reported_status: :lan}
+        |> update_derived_status()
+        |> update_connection_status()
+        |> maybe_start_soft_recovery_timer()
 
-    {:noreply, new_state}
+      {:noreply, new_state}
+    end
   end
 
   def handle_info(
@@ -413,8 +421,9 @@ defmodule VintageNetQMI.Connectivity do
 
     # Si venimos de LAN (o cualquier estado que no sea internet real validado), incrementamos intentos.
     # Esto captura el caso de flapping donde nunca llega a dispararse el timer.
+    # Cap at 3 to avoid infinite increment - after 3 we stay disconnected anyway
     new_attempts =
-      if state.reported_status == :lan or state.reported_status == :internet,
+      if (state.reported_status == :lan or state.reported_status == :internet) and state.soft_recovery_attempts < 3,
         do: state.soft_recovery_attempts + 1,
         else: state.soft_recovery_attempts
 

--- a/lib/vintage_net_qmi/internet_checker.ex
+++ b/lib/vintage_net_qmi/internet_checker.ex
@@ -77,14 +77,16 @@ defmodule VintageNetQMI.InternetChecker do
     cond do
       not lower_up? ->
         # If the interface isn't up, it's definitely disconnected.
+        # Reset consecutive_ping_failures so we start fresh when interface comes back up
         RouteManager.set_connection_status(ifname, :disconnected, "qmi_ifdown")
-        %{state | inspector: %{}, ping_list: []}
+        %{state | inspector: %{}, ping_list: [], consecutive_ping_failures: 0}
 
       not has_ipv4_address?(VintageNet.get(["interface", ifname, "addresses"])) ->
         # For QMI, if we don't even have IPv4, treat it as disconnected. This
         # prevents "LAN (timeout)" behavior when there's no SIM/no DHCP lease.
+        # Reset consecutive_ping_failures so we start fresh when IP is assigned
         RouteManager.set_connection_status(ifname, :disconnected, "qmi_no_ipv4")
-        %{state | inspector: %{}, ping_list: []}
+        %{state | inspector: %{}, ping_list: [], consecutive_ping_failures: 0}
 
       true ->
         # 1) Try to infer internet from TCP activity

--- a/lib/vintage_net_qmi/internet_checker.ex
+++ b/lib/vintage_net_qmi/internet_checker.ex
@@ -15,12 +15,15 @@ defmodule VintageNetQMI.InternetChecker do
 
   @initial_check_ms 5_000
   @interval_ms 30_000
+  # After this many consecutive ping failures, report :disconnected instead of :lan
+  @max_ping_failures_before_disconnected 3
 
   @type state :: %{
           ifname: VintageNet.ifname(),
           inspector: Inspector.cache(),
           configured_hosts: [{VintageNet.any_ip_address(), non_neg_integer()}],
-          ping_list: [{:inet.ip_address(), non_neg_integer()}]
+          ping_list: [{:inet.ip_address(), non_neg_integer()}],
+          consecutive_ping_failures: non_neg_integer()
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -35,7 +38,8 @@ defmodule VintageNetQMI.InternetChecker do
       ifname: ifname,
       inspector: %{},
       configured_hosts: HostList.load(),
-      ping_list: []
+      ping_list: [],
+      consecutive_ping_failures: 0
     }
 
     {:ok, state, {:continue, :continue}}
@@ -91,7 +95,8 @@ defmodule VintageNetQMI.InternetChecker do
           :internet ->
             RouteManager.set_connection_status(ifname, :internet, "qmi_inspector")
             PMControl.pet_watchdog(ifname)
-            state
+            # Reset consecutive ping failures since we have internet
+            %{state | consecutive_ping_failures: 0}
 
           :no_internet ->
             # No IPv4 would have been caught above; keep calm and don't override
@@ -132,13 +137,24 @@ defmodule VintageNetQMI.InternetChecker do
       :ok ->
         RouteManager.set_connection_status(state.ifname, :internet, "qmi_ping")
         PMControl.pet_watchdog(state.ifname)
-        %{state | ping_list: rest}
+        # Reset consecutive failures on success
+        %{state | ping_list: rest, consecutive_ping_failures: 0}
 
       other ->
-        Logger.debug("[VintageNetQMI] internet ping failed on #{state.ifname}: #{inspect(other)}")
-        # If ping explicitly fails, downgrade to :lan so Connectivity can handle recovery
-        RouteManager.set_connection_status(state.ifname, :lan, "qmi_ping_failed")
-        %{state | ping_list: rest}
+        new_failures = state.consecutive_ping_failures + 1
+        Logger.debug("[VintageNetQMI] internet ping failed on #{state.ifname}: #{inspect(other)} (consecutive: #{new_failures})")
+
+        # After @max_ping_failures_before_disconnected consecutive failures,
+        # report :disconnected instead of :lan so watchdog is NOT petted
+        if new_failures >= @max_ping_failures_before_disconnected do
+          Logger.warning("[VintageNetQMI] #{state.ifname}: #{new_failures} consecutive ping failures, reporting :disconnected")
+          RouteManager.set_connection_status(state.ifname, :disconnected, "qmi_ping_failed_#{new_failures}x")
+        else
+          # Still within tolerance, report :lan so Connectivity can handle recovery
+          RouteManager.set_connection_status(state.ifname, :lan, "qmi_ping_failed")
+        end
+
+        %{state | ping_list: rest, consecutive_ping_failures: new_failures}
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements stricter recovery and connectivity reporting to avoid flapping and let the watchdog intervene when needed.
> 
> - Enforce a max of 3 soft recovery attempts in `connectivity.ex`; ignore `:lan` reports and block `:lan` transitions after the limit, keeping `reported_status` `:disconnected` and logging why
> - Cap incrementing `soft_recovery_attempts`; cancel recovery/stability timers on disconnect and reset attempts only after stable `:internet`
> - In `internet_checker.ex`, track `consecutive_ping_failures`; reset on success or link/IP changes; after ≥3 failures, set connection to `:disconnected` (else `:lan`) and avoid petting the watchdog
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8162c75373b01f9b888a172af8c08bbfde635956. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->